### PR TITLE
Add the issue tracker in the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,8 @@
         "branch-alias": {
             "dev-master": "1.0-dev"
         }
+    },
+    "support": {
+        "issues": "https://github.com/puli/puli/issues"
     }
 }


### PR DESCRIPTION
This is not necessary for Github projects in general, because Composer checks whether the issue tracker is enabled on the repo and configure this automatically. But given that you expect issues to be reported on puli/puli instead, it is better to advocate it (`composer show puli/discovery` will show it, and Packagist will link to it as well)
