### PR TITLE
define() README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Latest release: [1.0.0-beta4](https://packagist.org/packages/puli/discovery#1.0.
 PHP >= 5.3.9
 
 The [Puli] Discovery Component supports binding of Puli resources to *binding
-types*. Binding types can be defined with the `define()` method of the 
+types*. Binding types can be defined with the `defineType()` method of the 
 [`EditableDiscovery`] interface:
 
 ```php
@@ -22,7 +22,7 @@ use Puli\Discovery\InMemoryDiscovery;
 // $repo is a Puli repository
 $discovery = new InMemoryDiscovery($repo);
 
-$discovery->define('doctrine/xml-mapping');
+$discovery->defineType('doctrine/xml-mapping');
 ```
 
 Resources in the repository can then be bound to the defined type with `bind()`:

--- a/src/Api/EditableDiscovery.php
+++ b/src/Api/EditableDiscovery.php
@@ -21,13 +21,13 @@ use Puli\Repository\Api\UnsupportedLanguageException;
  * A discovery that supports the addition and removal of bindings and types.
  *
  * Binding types have a name and optionally one or more parameters. Binding
- * types can be defined with the {@link define()} method:
+ * types can be defined with the {@link defineType()} method:
  *
  * ```php
  * use Puli\Discovery\Api\Binding\BindingParameter;
  * use Puli\Discovery\Api\Binding\BindingType;
  *
- * $discovery->define(new BindingType('acme/xliff-messages', array(
+ * $discovery->defineType(new BindingType('acme/xliff-messages', array(
  *     new BindingParameter('translationDomain', null, 'messages'),
  * ));
  * ```
@@ -111,7 +111,7 @@ interface EditableDiscovery extends ResourceDiscovery
      * use Puli\Discovery\Api\Binding\BindingParameter;
      * use Puli\Discovery\Api\Binding\BindingType;
      *
-     * $binder->define(new BindingType('acme/xliff-message', array(
+     * $binder->defineType(new BindingType('acme/xliff-message', array(
      *     new BindingParameter('translationDomain', null, 'messages'),
      * ));
      * ```


### PR DESCRIPTION
In README is still the method `define()` mentioned while in `EditableDiscovery` it is actually `defineType()`. This PR is just a minor fix of the Discovery README file.

The API documentation on http://api.puli.io/latest/class-Puli.Discovery.Api.EditableDiscovery.html still has `define()` in its first example too, so I changed the DocBlocks of `EditableDiscovery`.