### PR TITLE
Added support for search/removal using Expression instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Changelog
  * removed `LazyBinding`
  * added `ResourceBindingInitializer`
  * adapted data structures stored by `KeyValueStoreDiscovery`
+ * added support for search/removal using `Expression` instances
 
 * 1.0.0-beta7 (2015-08-24)
 

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,9 @@
     "require": {
         "php": ">=5.3.9",
         "puli/repository": "^1.0",
-        "webmozart/glob": ">=2.0,<4.0",
         "webmozart/assert": "^1.0",
+        "webmozart/expression": "^1.0.0-beta5",
+        "webmozart/glob": ">=2.0,<4.0",
         "ramsey/uuid": "^2.8"
     },
     "require-dev": {

--- a/src/Api/Discovery.php
+++ b/src/Api/Discovery.php
@@ -16,6 +16,7 @@ use Puli\Discovery\Api\Binding\NoSuchBindingException;
 use Puli\Discovery\Api\Type\BindingType;
 use Puli\Discovery\Api\Type\NoSuchTypeException;
 use Rhumsaa\Uuid\Uuid;
+use Webmozart\Expression\Expression;
 
 /**
  * Discovers artifacts.
@@ -58,12 +59,12 @@ interface Discovery
      *
      * This method returns an empty array if the given type is not defined.
      *
-     * @param string $typeName        The name of the binding type.
-     * @param array  $parameterValues The parameter values to match.
+     * @param string          $typeName The name of the binding type.
+     * @param Expression|null $expr     The expression to filter by.
      *
      * @return Binding[] The matching bindings.
      */
-    public function findBindings($typeName, array $parameterValues = array());
+    public function findBindings($typeName, Expression $expr = null);
 
     /**
      * Returns whether the discovery contains bindings.
@@ -74,14 +75,12 @@ interface Discovery
      *
      * This method returns `false` if the passed type does not exist.
      *
-     * @param string|null $typeName        The name of the binding type or
-     *                                     `null` to check whether the discovery
-     *                                     has bindings with any type.
-     * @param array       $parameterValues The parameter values to match.
+     * @param string|null     $typeName The name of the binding type.
+     * @param Expression|null $expr     The expression to filter by.
      *
      * @return bool Returns whether the discovery contains matching bindings.
      */
-    public function hasBindings($typeName = null, array $parameterValues = array());
+    public function hasBindings($typeName = null, Expression $expr = null);
 
     /**
      * Returns all bindings.

--- a/src/Api/EditableDiscovery.php
+++ b/src/Api/EditableDiscovery.php
@@ -19,6 +19,7 @@ use Puli\Discovery\Api\Type\MissingParameterException;
 use Puli\Discovery\Api\Type\NoSuchParameterException;
 use Puli\Discovery\Api\Type\NoSuchTypeException;
 use Rhumsaa\Uuid\Uuid;
+use Webmozart\Expression\Expression;
 
 /**
  * A discovery that supports the addition and removal of bindings and types.
@@ -38,15 +39,17 @@ use Rhumsaa\Uuid\Uuid;
  * Bindings can be added for these types with the {@link addBinding()} method:
  *
  * ```php
- * $discovery->bind('/app/trans/errors.*.xlf', 'acme/xliff-messages', array(
- *     'translationDomain' => 'errors',
- * ));
+ * $discovery->addBinding(
+ *     new ResourceBinding('/app/trans/errors.*.xlf', 'acme/xliff-messages', array(
+ *         'translationDomain' => 'errors',
+ *     ),
+ * );
  * ```
  *
- * Use {@link find()} to retrieve bindings for a given type:
+ * Use {@link findBindings()} to retrieve bindings for a given type:
  *
  * ```php
- * $bindings = $discovery->find('acme/xliff-messages');
+ * $bindings = $discovery->findBindings('acme/xliff-messages');
  *
  * foreach ($bindings as $binding) {
  *     foreach ($binding->getResources() as $resource) {
@@ -98,11 +101,11 @@ interface EditableDiscovery extends Discovery
      * If no matching bindings are found or if the type does not exist this
      * method does nothing.
      *
-     * @param string|null $typeName        The name of the binding type or
-     *                                     `null` to remove all bindings.
-     * @param array       $parameterValues The parameter values to match.
+     * @param string|null     $typeName The name of the binding type or `null`
+     *                                  to remove all bindings.
+     * @param Expression|null $expr     The expression to filter by.
      */
-    public function removeBindings($typeName = null, array $parameterValues = array());
+    public function removeBindings($typeName = null, Expression $expr = null);
 
     /**
      * Adds a binding type to the discovery.

--- a/src/NullDiscovery.php
+++ b/src/NullDiscovery.php
@@ -17,6 +17,7 @@ use Puli\Discovery\Api\EditableDiscovery;
 use Puli\Discovery\Api\Type\BindingType;
 use Puli\Discovery\Api\Type\NoSuchTypeException;
 use Rhumsaa\Uuid\Uuid;
+use Webmozart\Expression\Expression;
 
 /**
  * A discovery that does nothing.
@@ -34,7 +35,7 @@ class NullDiscovery implements EditableDiscovery
     /**
      * {@inheritdoc}
      */
-    public function findBindings($typeName, array $parameterValues = array())
+    public function findBindings($typeName, Expression $expr = null)
     {
         return array();
     }
@@ -42,7 +43,7 @@ class NullDiscovery implements EditableDiscovery
     /**
      * {@inheritdoc}
      */
-    public function hasBindings($typeName = null, array $parameterValues = array())
+    public function hasBindings($typeName = null, Expression $expr = null)
     {
         return false;
     }
@@ -120,7 +121,7 @@ class NullDiscovery implements EditableDiscovery
     /**
      * {@inheritdoc}
      */
-    public function removeBindings($typeName = null, array $parameterValues = array())
+    public function removeBindings($typeName = null, Expression $expr = null)
     {
     }
 

--- a/tests/KeyValueStoreDiscoveryUnloadedTest.php
+++ b/tests/KeyValueStoreDiscoveryUnloadedTest.php
@@ -18,6 +18,7 @@ use Puli\Discovery\Binding\ClassBinding;
 use Puli\Discovery\Binding\ResourceBinding;
 use Puli\Discovery\KeyValueStoreDiscovery;
 use Puli\Discovery\Tests\Fixtures\Foo;
+use Webmozart\Expression\Expr;
 use Webmozart\KeyValueStore\SerializingArrayStore;
 
 /**
@@ -174,7 +175,7 @@ class KeyValueStoreDiscoveryUnloadedTest extends AbstractEditableDiscoveryTest
         $discovery = $this->loadDiscoveryFromStorage($discovery);
 
         // Bindings need to be initialized for this to work
-        $discovery->removeBindings(Foo::clazz, array('param1' => 'foo'));
+        $discovery->removeBindings(Foo::clazz, Expr::method('getParameterValue', 'param1', Expr::same('foo')));
 
         $this->assertEquals(array($binding3), $discovery->findBindings(Foo::clazz));
         $this->assertEquals(array($binding3), $discovery->getBindings());


### PR DESCRIPTION
This PR makes search/removal in Discovery objects a bit more flexible, which is needed in practice where you may want to search bindings by query/class name.