### PR TITLE
Updated uuid library to 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "webmozart/assert": "^1.0",
         "webmozart/expression": "^1.0.0-beta5",
         "webmozart/glob": ">=2.0,<4.0",
-        "ramsey/uuid": "^2.8"
+        "ramsey/uuid": "^3.0"
     },
     "require-dev": {
         "webmozart/key-value-store": "^1.0.0-beta6",

--- a/src/Api/Binding/Binding.php
+++ b/src/Api/Binding/Binding.php
@@ -16,7 +16,7 @@ use Puli\Discovery\Api\Type\BindingNotAcceptedException;
 use Puli\Discovery\Api\Type\BindingType;
 use Puli\Discovery\Api\Type\MissingParameterException;
 use Puli\Discovery\Api\Type\NoSuchParameterException;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 use Serializable;
 
 /**

--- a/src/Api/Binding/NoSuchBindingException.php
+++ b/src/Api/Binding/NoSuchBindingException.php
@@ -12,7 +12,7 @@
 namespace Puli\Discovery\Api\Binding;
 
 use Exception;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 use RuntimeException;
 
 /**

--- a/src/Api/Discovery.php
+++ b/src/Api/Discovery.php
@@ -15,7 +15,7 @@ use Puli\Discovery\Api\Binding\Binding;
 use Puli\Discovery\Api\Binding\NoSuchBindingException;
 use Puli\Discovery\Api\Type\BindingType;
 use Puli\Discovery\Api\Type\NoSuchTypeException;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 use Webmozart\Expression\Expression;
 
 /**

--- a/src/Api/EditableDiscovery.php
+++ b/src/Api/EditableDiscovery.php
@@ -18,7 +18,7 @@ use Puli\Discovery\Api\Type\DuplicateTypeException;
 use Puli\Discovery\Api\Type\MissingParameterException;
 use Puli\Discovery\Api\Type\NoSuchParameterException;
 use Puli\Discovery\Api\Type\NoSuchTypeException;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 use Webmozart\Expression\Expression;
 
 /**

--- a/src/Binding/AbstractBinding.php
+++ b/src/Binding/AbstractBinding.php
@@ -18,7 +18,7 @@ use Puli\Discovery\Api\Type\BindingNotAcceptedException;
 use Puli\Discovery\Api\Type\BindingType;
 use Puli\Discovery\Api\Type\MissingParameterException;
 use Puli\Discovery\Api\Type\NoSuchParameterException;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 use Webmozart\Assert\Assert;
 
 /**

--- a/src/Binding/ClassBinding.php
+++ b/src/Binding/ClassBinding.php
@@ -13,7 +13,7 @@ namespace Puli\Discovery\Binding;
 
 use Puli\Discovery\Api\Type\MissingParameterException;
 use Puli\Discovery\Api\Type\NoSuchParameterException;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Binds a class name to a binding type.

--- a/src/Binding/ResourceBinding.php
+++ b/src/Binding/ResourceBinding.php
@@ -16,7 +16,7 @@ use Puli\Discovery\Api\Type\MissingParameterException;
 use Puli\Discovery\Api\Type\NoSuchParameterException;
 use Puli\Repository\Api\ResourceCollection;
 use Puli\Repository\Api\ResourceRepository;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Binds one or more resources to a binding type.

--- a/src/InMemoryDiscovery.php
+++ b/src/InMemoryDiscovery.php
@@ -16,7 +16,7 @@ use Puli\Discovery\Api\Binding\NoSuchBindingException;
 use Puli\Discovery\Api\Type\BindingType;
 use Puli\Discovery\Api\Type\DuplicateTypeException;
 use Puli\Discovery\Api\Type\NoSuchTypeException;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 use Webmozart\Assert\Assert;
 use Webmozart\Expression\Expression;
 

--- a/src/KeyValueStoreDiscovery.php
+++ b/src/KeyValueStoreDiscovery.php
@@ -17,7 +17,7 @@ use Puli\Discovery\Api\Binding\NoSuchBindingException;
 use Puli\Discovery\Api\Type\BindingType;
 use Puli\Discovery\Api\Type\DuplicateTypeException;
 use Puli\Discovery\Api\Type\NoSuchTypeException;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 use RuntimeException;
 use Webmozart\Assert\Assert;
 use Webmozart\Expression\Expression;

--- a/src/NullDiscovery.php
+++ b/src/NullDiscovery.php
@@ -16,7 +16,7 @@ use Puli\Discovery\Api\Binding\NoSuchBindingException;
 use Puli\Discovery\Api\EditableDiscovery;
 use Puli\Discovery\Api\Type\BindingType;
 use Puli\Discovery\Api\Type\NoSuchTypeException;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 use Webmozart\Expression\Expression;
 
 /**

--- a/tests/AbstractDiscoveryTest.php
+++ b/tests/AbstractDiscoveryTest.php
@@ -21,7 +21,7 @@ use Puli\Discovery\Binding\ClassBinding;
 use Puli\Discovery\Binding\ResourceBinding;
 use Puli\Discovery\Tests\Fixtures\Bar;
 use Puli\Discovery\Tests\Fixtures\Foo;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 use stdClass;
 use Webmozart\Expression\Expr;
 

--- a/tests/AbstractEditableDiscoveryTest.php
+++ b/tests/AbstractEditableDiscoveryTest.php
@@ -21,7 +21,7 @@ use Puli\Discovery\Binding\ClassBinding;
 use Puli\Discovery\Binding\ResourceBinding;
 use Puli\Discovery\Tests\Fixtures\Bar;
 use Puli\Discovery\Tests\Fixtures\Foo;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 use stdClass;
 use Webmozart\Expression\Expr;
 

--- a/tests/Binding/AbstractBindingTest.php
+++ b/tests/Binding/AbstractBindingTest.php
@@ -17,7 +17,7 @@ use Puli\Discovery\Api\Type\BindingType;
 use Puli\Discovery\Binding\AbstractBinding;
 use Puli\Discovery\Tests\Fixtures\Bar;
 use Puli\Discovery\Tests\Fixtures\Foo;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 use stdClass;
 
 /**
@@ -43,7 +43,7 @@ abstract class AbstractBindingTest extends PHPUnit_Framework_TestCase
         $this->assertSame(Foo::clazz, $binding->getTypeName());
         $this->assertSame(array(), $binding->getParameterValues());
         $this->assertFalse($binding->hasParameterValue('param'));
-        $this->assertInstanceOf('Rhumsaa\Uuid\Uuid', $binding->getUuid());
+        $this->assertInstanceOf('Ramsey\Uuid\Uuid', $binding->getUuid());
     }
 
     public function testCreateWithUuid()

--- a/tests/Binding/ClassBindingTest.php
+++ b/tests/Binding/ClassBindingTest.php
@@ -13,7 +13,7 @@ namespace Puli\Discovery\Tests\Binding;
 
 use Puli\Discovery\Binding\ClassBinding;
 use Puli\Discovery\Tests\Fixtures\Foo;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @since  1.0

--- a/tests/Binding/ResourceBindingTest.php
+++ b/tests/Binding/ResourceBindingTest.php
@@ -13,7 +13,7 @@ namespace Puli\Discovery\Tests\Binding;
 
 use Puli\Discovery\Binding\ResourceBinding;
 use Puli\Discovery\Tests\Fixtures\Foo;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @since  1.0


### PR DESCRIPTION
See https://github.com/ramsey/uuid#upgrading-from-2x-to-3x

Note that this is needed to support the 3.0 versions of the Symfony components in Puli (ramsey/uuid 2.8 uses symfony/console ~2.3).