### PR TITLE
Moved webmozart/json to requirements instead of require-dev.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     "require": {
         "php": "^5.3.9|^7.0",
         "webmozart/assert": "^1.0",
-        "webmozart/expression": "^1.0"
+        "webmozart/expression": "^1.0",
+        "webmozart/json": "^1.2"
     },
     "require-dev": {
         "webmozart/key-value-store": "^1.0-beta7",
-        "webmozart/json": "^1.2",
         "phpunit/phpunit": "^4.6",
         "sebastian/version": "^1.0.1"
     },


### PR DESCRIPTION
Since [we are using](https://github.com/puli/discovery/blob/master/src/JsonDiscovery.php#L22-L23) classes from the `webmozart/json` we need to make sure to require the `webmozart/json` in composer.json. Putting it in require-dev is not good enough. 